### PR TITLE
bugfix: inifite scroll doesn't work for selectize theme

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,7 +81,7 @@ angular
 
                     var lastChoice = angular.element(rows[rows.length - 1]);
 
-                    container = angular.element(elem.querySelectorAll('.ui-select-choices'));
+                    container = angular.element(elem.querySelectorAll('.ui-select-choices-content'));
 
                     var handler = function() {
                         var containerBottom = height(container),


### PR DESCRIPTION
Basically the css selector .ui-select-choices will select the parent div which is not scrollable for selectize theme. 

This is a fix for https://github.com/hyzhak/ui-select-infinity/issues/6
