### PR TITLE
Refresh the rows for height and offset on every change

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@
 
 angular
     .module('ui-select-infinity', [])
-    .directive('reachInfinity', ['$parse', '$timeout', function($parse, $timeout) {
+    .directive('reachInfinity', ['$parse', '$timeout', '$q', function($parse, $timeout, $q) {
         function height(elem) {
             elem = elem[0] || elem;
             if (isNaN(elem.offsetHeight)) {
@@ -69,7 +69,7 @@ angular
         return {
             link: function(scope, elem, attrs) {
                 var container = elem,
-                    scrollDistance = 0.3,
+                    scrollDistance = angular.isDefined(attrs.scrollDistance) ? parseInt(attrs.scrollDistance) : 0.3,
                     removeThrottle;
 
                 function tryToSetupInfinityScroll() {
@@ -95,11 +95,14 @@ angular
                         elementBottom = offsetTop(lastChoice) - containerTopOffset + height(lastChoice);
 
                         var remaining = elementBottom - containerBottom,
-                            shouldScroll = remaining <= height(container) * scrollDistance + 1;
+                            shouldScroll = remaining <= height(container) * (scrollDistance + 1);
 
                         if (shouldScroll) {
-                            scope.$apply(function() {
-                                $parse(attrs['reachInfinity'])(scope);
+                            $q.when($parse(attrs['reachInfinity'])(scope)).then(function() {
+                                setTimeout(function() {
+                                    rows = elem.querySelectorAll('.ui-select-choices-row');
+                                    lastChoice = angular.element(rows[rows.length - 1]);
+                                }, 0);
                             });
                         }
                     };


### PR DESCRIPTION
This commit ensures the infinite scroll handler is only executed, if the container is scrolled until the scrollDistance. Prior only the initial height was used, so if the height has changed, due to new elements being added, these were not considered in the new height.

Also I've put the scroll distance into the attributes, and defaulted the value to 0.3 so you can adjusted it from the outside.
