### PR TITLE
Fix IE incompatibility when calling dispatchEvent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ui-select-infinity [![npm version](https://badge.fury.io/js/ui-select-infinity.svg)](http://badge.fury.io/js/ui-select-infinity)
 Extend `ui-select` with feature of infinity scrolling.
 
+This is a fork of https://github.com/hyzhak/ui-select-infinity that also works for IE >= 9. As that project seems not to be maintained, I forked the project in order to have this IE support.
+
 ## Installing
 
 ```
@@ -17,11 +19,11 @@ angular
         var loadingItem = {type: 'loading'},
             hasNextChunk = true,
             queryString = '';
-            
+
         function getInfinityScrollChunk(id) {
             //implement your lazy data request here
         }
-            
+
         function addLoadingStateItem() {
             $scope.collections.push(loadingItem);
         }
@@ -31,22 +33,22 @@ angular
             if (index < 0) {
                 return;
             }
-            
+
             $scope.collections.splice(index, 1);
         }
-        
+
         
         $scope.isItemMatch = function($select) {
             //implement your match function here by $select.search   
         };
-            
+
         $scope.requestMoreItems = function() {
             if ($scope.isRequestMoreItems || !hasNextChunk) {
                 return $q.reject();
             }
 
             addLoadingStateItem();
-            
+
             $scope.isRequestMoreItems = true;
             return getInfinityScrollChunk(nextChunkId)
                 .then(function(newItems) {
@@ -61,7 +63,7 @@ angular
                     $scope.isRequestMoreItems = false;
                 });
         };
-        
+
         $scope.refreshList = function() {
             queryString = query;
         };

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,7 @@
 {
-  "name": "ui-select-infinity",
-  "version": "0.1.6",
-  "homepage": "https://github.com/hyzhak/ui-select-infinity",
-  "authors": [
-    "Eugene Krevenets <ievgenii.krevenets@gmail.com> (http://hyzhak.github.io)"
-  ],
+  "name": "ui-select-infinity-ie",
+  "version": "0.1.7",
+  "homepage": "https://github.com/bastidiaaz/ui-select-infinity-ie",
   "description": "Extend `ui-select` with feature of infinity scrolling",
   "main": "lib/index.js",
   "moduleType": [

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,13 @@ angular
 
                 running = true;
                 requestAnimationFrame(function() {
-                    obj.dispatchEvent(new CustomEvent(name));
+                    try {
+                        obj.dispatchEvent(new CustomEvent(name));
+                    } catch (e) {
+                        var evt = document.createEvent("Event");
+                        evt.initEvent(name, false, true);
+                        obj.dispatchEvent(evt);
+                    }
                     running = false;
                 });
             };


### PR DESCRIPTION
Currently you got an error on IE 9 >= when firing `obj.dispatchEvent(new CustomEvent(name))` on line 57 on `index.js`. This PR solves that.